### PR TITLE
Add Plack::Builder to dependencies

### DIFF
--- a/.openshift/cpan.txt
+++ b/.openshift/cpan.txt
@@ -1,5 +1,6 @@
 Test::Base
 YAML
+Plack::Builder
 Dancer
 Plack::Handler::Apache2
 


### PR DESCRIPTION
Add `Plack::Builder` to `.openshift/cpan.txt` so that the build works on first try.

Without the explicit dependency on `Plack::Builder` before `Dancer`, `cpanm` fails in the initial build (but does succeed if rerun).

Note that this PR depends on https://github.com/openshift/origin-server/pull/6145 to respect the ordering in `cpan.txt`.